### PR TITLE
Ensure `_super` is called in `init`.

### DIFF
--- a/addon/services/scroll-activity.js
+++ b/addon/services/scroll-activity.js
@@ -12,6 +12,8 @@ export default Service.extend(Evented, {
   subscribers: null,
 
   init() {
+    this._super(...arguments);
+
     this.set('subscribers', A());
     this.subscribe(document, document);
     this._pollScroll();
@@ -67,5 +69,7 @@ export default Service.extend(Evented, {
       clearTimeout(this._animationFrame);
     }
     this.set('subscribers', null);
+
+    this._super(...arguments);
   }
 });

--- a/addon/services/user-activity.js
+++ b/addon/services/user-activity.js
@@ -44,6 +44,8 @@ export default Service.extend(Evented, {
   },
 
   init() {
+    this._super(...arguments);
+
     if (testing) { // Do not throttle in testing mode
       this.set('EVENT_THROTTLE', 0);
     }
@@ -98,5 +100,7 @@ export default Service.extend(Evented, {
     this.get('_eventsListened').forEach((eventName) => {
       this.disableEvent(eventName);
     });
+
+    this._super(...arguments);
   }
 });

--- a/addon/services/user-idle.js
+++ b/addon/services/user-idle.js
@@ -22,6 +22,8 @@ export default Service.extend({
   },
 
   init() {
+    this._super(...arguments);
+
     if (testing) { // Shorter debounce in testing mode
       this.set('IDLE_TIMEOUT', 10);
     }
@@ -34,6 +36,8 @@ export default Service.extend({
     if (this._debouncedTimeout) {
       cancel(this._debouncedTimeout);
     }
+
+    this._super(...arguments);
   },
 
   resetTimeout() {


### PR DESCRIPTION
If `_super` is not called during `init`, then any upstream changes (or `Ember.Service.reopen` added functionality) will not be properly invoked.