### PR TITLE
Event Teardown Should Call `off`

### DIFF
--- a/tests/dummy/app/components/event-display.js
+++ b/tests/dummy/app/components/event-display.js
@@ -19,7 +19,7 @@ export default Component.extend({
   },
 
   willDestroyElement() {
-    this.get('userActivity').on(this.get('eventName'), this, this.registerActivity);
+    this.get('userActivity').off(this.get('eventName'), this, this.registerActivity);
   },
 
   registerActivity(event) {


### PR DESCRIPTION
Tearing down each event requires calling 'off' for each event. This matches the README documentation for teardown