### PR TITLE
Drop unnecessary EmberObject.create

### DIFF
--- a/addon/services/scroll-activity.js
+++ b/addon/services/scroll-activity.js
@@ -1,6 +1,5 @@
 import $ from 'jquery';
 import Evented from 'ember-evented';
-import EmberObject from 'ember-object';
 import Service from 'ember-service';
 import { A } from 'ember-array/utils';
 import { bind } from 'ember-runloop';
@@ -23,12 +22,12 @@ export default Service.extend(Evented, {
     if (!element.scrollTop) { // a DOM element instead of a jQuery object
       element = $(element);
     }
-    this.get('subscribers').pushObject(EmberObject.create({
+    this.get('subscribers').pushObject({
       target,
       element,
       callback,
       scrollTop: element.scrollTop() // get scroll pos
-    }));
+    });
   },
 
   unsubscribe(target) {
@@ -48,11 +47,11 @@ export default Service.extend(Evented, {
     if (isPresent(subscribers)) {
       let hasScrolled = false;
       subscribers.forEach(function (subscriber) {
-        let scrollTop = subscriber.get('element').scrollTop();
-        if (scrollTop !== subscriber.get('scrollTop')) {
+        let scrollTop = subscriber.element.scrollTop();
+        if (scrollTop !== subscriber.scrollTop) {
           hasScrolled = true;
-          subscriber.get('callback')(scrollTop, subscriber.get('scrollTop'));
-          subscriber.set('scrollTop', scrollTop);
+          subscriber.callback(scrollTop, subscriber.scrollTop);
+          subscriber.scrollTop = scrollTop;
         }
       });
       if (hasScrolled) {

--- a/tests/unit/services/scroll-activity-test.js
+++ b/tests/unit/services/scroll-activity-test.js
@@ -11,7 +11,7 @@ test('init', function (assert) {
     _pollScroll: this.stub()
   });
 
-  assert.ok(isEmberArray(service.get('subscribers')), 'sets subscribers to new Ember.A');
+  assert.ok(isEmberArray(service.subscribers), 'sets subscribers to new Ember.A');
   assert.ok(service.subscribe.calledOnce, 'subscribe was called');
   assert.ok(service._pollScroll.calledOnce, '_pollScroll was called');
 });
@@ -34,10 +34,10 @@ test('subscribe - no callback', function (assert) {
   assert.equal(service.get('subscribers.length'), 1, '1 subscriber added');
 
   let sub = service.get('subscribers.firstObject');
-  assert.equal(sub.get('target'), target, 'target added to subscriber object');
-  assert.equal(sub.get('element'), elem, 'element added to subscriber object');
-  assert.equal(typeof(sub.get('callback')), 'function', 'no-op function added when callback not provided');
-  assert.equal(sub.get('scrollTop'), scrollTop, 'scrollTop added to subscriber object');
+  assert.equal(sub.target, target, 'target added to subscriber object');
+  assert.equal(sub.element, elem, 'element added to subscriber object');
+  assert.equal(typeof(sub.callback), 'function', 'no-op function added when callback not provided');
+  assert.equal(sub.scrollTop, scrollTop, 'scrollTop added to subscriber object');
 });
 
 test('subscribe - with callback', function (assert) {
@@ -59,10 +59,10 @@ test('subscribe - with callback', function (assert) {
   assert.equal(service.get('subscribers.length'), 1, '1 subscriber added');
 
   let sub = service.get('subscribers.firstObject');
-  assert.equal(sub.get('target'), target, 'target added to subscriber object');
-  assert.equal(sub.get('element'), elem, 'element added to subscriber object');
-  assert.equal(sub.get('callback'), callback, 'callback added to subscriber object');
-  assert.equal(sub.get('scrollTop'), scrollTop, 'scrollTop added to subscriber object');
+  assert.equal(sub.target, target, 'target added to subscriber object');
+  assert.equal(sub.element, elem, 'element added to subscriber object');
+  assert.equal(sub.callback, callback, 'callback added to subscriber object');
+  assert.equal(sub.scrollTop, scrollTop, 'scrollTop added to subscriber object');
 });
 
 test('unsubscribe', function (assert) {


### PR DESCRIPTION
Using Ember objects for the subscribers isn't needed. There are probably some other emberisms that are overkill, but dropping `create` from these objects that don't need observation would be great. POJOs seem to work fine.