### PR TITLE
Fixes #85 - Don't Require getOwner Polyfill for >2.3

### DIFF
--- a/addon/mixins/fastboot-compat.js
+++ b/addon/mixins/fastboot-compat.js
@@ -1,5 +1,5 @@
 import Mixin from 'ember-metal/mixin';
-import getOwner from 'ember-getowner-polyfill';
+import getOwner from 'ember-owner/get';
 import computed from 'ember-computed';
 
 export default Mixin.create({

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-getowner-polyfill": "1.0.1",
+    "ember-getowner-polyfill": "1.1.0",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1547,7 +1547,7 @@ ember-cli-valid-component-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.4, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7:
+ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.4, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-1.2.0.tgz#caa286b77d1b485df5d2f62c67a6f19aa8b582c4"
   dependencies:
@@ -1650,11 +1650,12 @@ ember-export-application-global@^1.0.5:
   dependencies:
     ember-cli-babel "^5.1.10"
 
-ember-getowner-polyfill@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-1.0.1.tgz#f60a31d25d642461dac4b4746184afaf7f5084ae"
+ember-getowner-polyfill@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-1.1.0.tgz#8df71115a2442147418c3a9a545617ea44a04221"
   dependencies:
-    ember-cli-babel "^5.1.5"
+    ember-cli-babel "^5.1.6"
+    ember-cli-version-checker "^1.2.0"
 
 ember-load-initializers@^0.5.1:
   version "0.5.1"


### PR DESCRIPTION
Recent changes to ember-getowner-polyfill make it a true polyfill.

This lets us ship the polyfill to only environments that need it, and reduce
boilerplate code in addons.

The refactor is basically just:
```
import { getOwner } from 'ember-getowner-polyfill';

// ....snip....
getOwner(someThing);
```
To:
```
import getOwner from 'ember-owner/get';

// ....snip....
getOwner(someThing);
```