### PR TITLE
Avoid set on destroyed object

### DIFF
--- a/addon/services/user-idle.js
+++ b/addon/services/user-idle.js
@@ -51,6 +51,9 @@ export default Service.extend(Evented, {
   },
 
   setIdle() {
+    if (this.isDestroyed) {
+      return;
+    }
     this.set('isIdle', true);
     this.trigger('idleChanged', true);
   }


### PR DESCRIPTION
I couldn't make the tests run locally but it did fix the error in my app.

Fixes https://github.com/elwayman02/ember-user-activity/issues/122