### PR TITLE
Fix unsubscribe memory leak

### DIFF
--- a/addon/services/user-activity.js
+++ b/addon/services/user-activity.js
@@ -105,10 +105,9 @@ export default Service.extend(Evented, FastBootCompatMixin, {
   },
 
   willDestroy() {
-    this._eventsListened.forEach((eventName) => {
-      this.disableEvent(eventName);
-    });
-    this._eventsListened.length = 0;
+    while (this._eventsListened.length > 0) {
+      this.disableEvent(this._eventsListened[0]);
+    }
 
     this._super(...arguments);
   }

--- a/tests/unit/services/user-activity-test.js
+++ b/tests/unit/services/user-activity-test.js
@@ -143,4 +143,19 @@ module('Unit | Service | user activity', function(hooks) {
     assert.ok(service.isEnabled(event), 'event is enabled');
     assert.ok(!service.isEnabled('bar'), 'other events are not enabled');
   });
+
+  test('unsubscribe from events', function(assert) {
+    this.spy(window, 'addEventListener');
+    this.spy(window, 'removeEventListener');
+
+    const service = this.owner.factoryFor('service:user-activity').create();
+
+    assert.equal(window.addEventListener.callCount, 3, 'Subscribed to 3 window events');
+
+    service.willDestroy();
+    assert.equal(window.removeEventListener.callCount, 3, 'Unsubscribed from 3 window events');
+
+    window.addEventListener.restore();
+    window.removeEventListener.restore();
+  });
 });


### PR DESCRIPTION
In `user-activity`'s `willDestroy` there was an forEach loop by
`this._eventsListened` where inside the callback items were removed
from the array which was being iterated. As a result one item left
non-cleaned up.

Use regular while loop to clean up the array and add a test which
ensures that event listeners were removed.