### PR TITLE
Remove Ember Evented Mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ activeHandler(event) {
 Each event handler will receive the standard DOM `event` object
 (ex: [mousemove](https://developer.mozilla.org/en-US/docs/Web/Events/mousemove)).
 
+Unsubscribe from any event by calling `off`:
+
+```javascript
+this.get('userActivity').off('userActive', this, this.activeHandler);
+```
+
+#### Event Configuration
+
 If you would like to listen to a different set of events, extend the service in your app:
 
 ```javascript
@@ -87,6 +95,8 @@ You can find out if an event is currently enabled:
 this.get('userActivity').isEnabled('foo'); // false
 this.get('userActivity').isEnabled('keydown'); // true
 ```
+
+#### Performance Configuration
 
 Each individual event is throttled by 100ms for performance reasons,
 to avoid clogging apps with a firehose of activity events. The length of

--- a/addon/services/scroll-activity.js
+++ b/addon/services/scroll-activity.js
@@ -1,7 +1,7 @@
 import { getOwner } from '@ember/application';
 import { computed } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
-import Evented from '@ember/object/evented';
+import { addListener, removeListener, sendEvent } from '@ember/object/events';
 import { run } from '@ember/runloop';
 import Service from '@ember/service';
 import getScroll from '../utils/get-scroll';
@@ -20,7 +20,7 @@ const SCROLL_EVENT_TYPE_VERTICAL = 'vertical';
 const SCROLL_EVENT_TYPE_HORIZONTAL = 'horizontal';
 const SCROLL_EVENT_TYPE_DIAGONAL = 'diagonal';
 
-export default Service.extend(Evented, {
+export default Service.extend({
   // Fastboot Compatibility
   _fastboot: computed(function() {
     let owner = getOwner(this);
@@ -28,6 +28,21 @@ export default Service.extend(Evented, {
   }),
 
   _isFastBoot: readOnly('_fastboot.isFastBoot'),
+
+  // Evented Implementation: https://github.com/emberjs/ember.js/blob/v3.16.1/packages/%40ember/-internals/runtime/lib/mixins/evented.js#L13
+  on(name, target, method) {
+    addListener(this, name, target, method);
+    return this;
+  },
+
+  off(name, target, method) {
+    removeListener(this, name, target, method);
+    return this;
+  },
+
+  trigger(name, ...args) {
+    sendEvent(this, name, args);
+  },
 
   init() {
     this._super(...arguments);


### PR DESCRIPTION
@tylerturdenpants this definitely needs a thorough review, as I'm swapping out the Evented mixin for its underlying implementation but had to reimplement `has` my own way since the internal function isn't exported on any Ember module.