### PR TITLE
packages.json: Move dev-time dependencies into `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,8 @@
     "release": "release-it"
   },
   "dependencies": {
-    "ember-angle-bracket-invocation-polyfill": "^2.1.0",
     "ember-classic-decorator": "^2.0.0",
-    "ember-cli-babel": "^7.22.1",
-    "ember-cli-htmlbars": "^5.3.1",
-    "ember-decorators": "^6.1.1",
-    "ember-on-modifier": "^1.0.1"
+    "ember-cli-babel": "^7.22.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
@@ -40,6 +36,7 @@
     "@glimmer/tracking": "^1.0.2",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
+    "ember-angle-bracket-invocation-polyfill": "^2.1.0",
     "ember-auto-import": "^1.6.0",
     "ember-cli": "~3.21.2",
     "ember-cli-addon-docs": "^0.8.0",
@@ -50,16 +47,19 @@
     "ember-cli-deploy-build": "^2.0.0",
     "ember-cli-deploy-git": "^1.3.4",
     "ember-cli-deploy-git-ci": "^1.0.1",
+    "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-release": "1.0.0-beta.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",
+    "ember-decorators": "^6.1.1",
     "ember-decorators-polyfill": "^1.1.5",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-fn-helper-polyfill": "^1.0.2",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-on-modifier": "^1.0.1",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
     "ember-sinon": "^5.0.0",


### PR DESCRIPTION
All of these dependencies are only used by the dummy app, so there is no need to force other apps into shipping them too when using this addon ;)

/cc @elwayman02 