### PR TITLE
Configure continue-on-error for ember-{beta,canary}

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
     name: "ember-try: ${{ matrix.ember-try-scenario }}"
     runs-on: ubuntu-latest
     needs: test
+    continue-on-error: ${{ matrix.experimental }}
 
     strategy:
       fail-fast: true
@@ -51,10 +52,14 @@ jobs:
           - ember-lts-3.16
           - ember-lts-3.20
           - ember-release
-          - ember-beta
-          - ember-canary
           - ember-default-with-jquery
           - ember-classic
+        experimental: [false]
+        include:
+          - ember-try-scenario: ember-beta
+            experimental: true
+          - ember-try-scenario: ember-canary
+            experimental: true
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Configuring the `ember-beta` and `ember-canary` targets to have `continue-on-error` set to `true` so that they don't cause CI to fail if they fail. Unfortunately GitHub Actions doesn't provide great visibility into when these optional failures happen (see https://github.com/actions/toolkit/issues/399), but this is probably the best option for now.

This fixes #340.