### PR TITLE
Fix eslint decorator proposal version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
       plugins: [
         [
           '@babel/plugin-proposal-decorators',
-          { decoratorsBeforeExport: true, version: '2021-12' },
+          { decoratorsBeforeExport: true, version: '2018-09' },
         ],
       ],
     },


### PR DESCRIPTION
Per the docs, `decoratorsBeforeExport` cannot be true if `version` is `2021-12`. The correct version for the pattern this package uses is `2018-09`.

https://babeljs.io/docs/en/babel-plugin-proposal-decorators#decoratorsbeforeexport