### PR TITLE
Get rid of ember-classic-decorator dependency

### DIFF
--- a/addon/services/-private/event-manager.js
+++ b/addon/services/-private/event-manager.js
@@ -1,8 +1,6 @@
-import classic from 'ember-classic-decorator';
 import Service from '@ember/service';
 import { addListener, removeListener, sendEvent } from '@ember/object/events';
 
-@classic
 export default class EventManagerService extends Service {
   // Partial Evented Implementation: https://github.com/emberjs/ember.js/blob/v3.16.1/packages/%40ember/-internals/runtime/lib/mixins/evented.js#L13
   // one() was omitted from this implementation due to the way the user-activity service would need a lot of special behavior added

--- a/addon/services/-private/fastboot-aware-event-manager.js
+++ b/addon/services/-private/fastboot-aware-event-manager.js
@@ -1,10 +1,8 @@
-import classic from 'ember-classic-decorator';
 import { computed } from '@ember/object';
 import EventManagerService from 'ember-user-activity/services/-private/event-manager';
 import { getOwner } from '@ember/application';
 import { readOnly } from '@ember/object/computed';
 
-@classic
 export default class FastBootAwareEventManagerService extends EventManagerService {
   // Fastboot Compatibility
   @computed

--- a/addon/services/scroll-activity.js
+++ b/addon/services/scroll-activity.js
@@ -1,4 +1,3 @@
-import classic from 'ember-classic-decorator';
 import FastBootAwareEventManagerService from 'ember-user-activity/services/-private/fastboot-aware-event-manager';
 import { begin as beginRunloop, end as endRunloop } from '@ember/runloop';
 import getScroll from 'ember-user-activity/utils/get-scroll';
@@ -17,7 +16,6 @@ const SCROLL_EVENT_TYPE_VERTICAL = 'vertical';
 const SCROLL_EVENT_TYPE_HORIZONTAL = 'horizontal';
 const SCROLL_EVENT_TYPE_DIAGONAL = 'diagonal';
 
-@classic
 export default class ScrollActivityService extends FastBootAwareEventManagerService {
   init() {
     super.init(...arguments);

--- a/addon/services/user-activity.js
+++ b/addon/services/user-activity.js
@@ -1,13 +1,12 @@
-import classic from 'ember-classic-decorator';
 import FastBootAwareEventManagerService from 'ember-user-activity/services/-private/fastboot-aware-event-manager';
 import Ember from 'ember';
 import { A } from '@ember/array';
 import { throttle } from '@ember/runloop';
 import { inject as injectService } from '@ember/service';
 import { isEmpty } from '@ember/utils';
+import { set } from '@ember/object';
 import storageAvailable from '../utils/storage-available';
 
-@classic
 export default class UserActivityService extends FastBootAwareEventManagerService {
   @injectService('ember-user-activity@scroll-activity')
   scrollActivity;
@@ -26,7 +25,7 @@ export default class UserActivityService extends FastBootAwareEventManagerServic
 
     if (Ember.testing) {
       // Do not throttle in testing mode
-      this.set('EVENT_THROTTLE', 0);
+      set(this, 'EVENT_THROTTLE', 0);
     }
 
     this._boundEventHandler = this.handleEvent.bind(this);
@@ -35,7 +34,7 @@ export default class UserActivityService extends FastBootAwareEventManagerServic
     this._throttledEventHandlers = {};
 
     if (isEmpty(this.enabledEvents)) {
-      this.set('enabledEvents', A());
+      set(this, 'enabledEvents', A());
     }
     this._setupListeners();
   }

--- a/addon/services/user-idle.js
+++ b/addon/services/user-idle.js
@@ -1,10 +1,9 @@
-import classic from 'ember-classic-decorator';
 import Ember from 'ember';
 import EventManagerService from 'ember-user-activity/services/-private/event-manager';
 import { inject as injectService } from '@ember/service';
 import { cancel, debounce } from '@ember/runloop';
+import { set } from '@ember/object';
 
-@classic
 export default class UserIdleService extends EventManagerService {
   @injectService('ember-user-activity@user-activity')
   userActivity;
@@ -25,7 +24,7 @@ export default class UserIdleService extends EventManagerService {
 
     if (Ember.testing) {
       // Shorter debounce in testing mode
-      this.set('IDLE_TIMEOUT', 10);
+      set(this, 'IDLE_TIMEOUT', 10);
     }
     this._setupListeners('on');
     this.resetTimeout();
@@ -42,7 +41,7 @@ export default class UserIdleService extends EventManagerService {
 
   resetTimeout() {
     let oldIdle = this.isIdle;
-    this.set('isIdle', false);
+    set(this, 'isIdle', false);
     if (oldIdle) {
       this.trigger('idleChanged', false);
     }
@@ -53,7 +52,7 @@ export default class UserIdleService extends EventManagerService {
     if (this.isDestroyed) {
       return;
     }
-    this.set('isIdle', true);
+    set(this, 'isIdle', true);
     this.trigger('idleChanged', true);
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "release": "release-it"
   },
   "dependencies": {
-    "ember-classic-decorator": "^3.0.1",
     "ember-cli-babel": "^7.26.11"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6540,16 +6540,6 @@ ember-cached-decorator-polyfill@^1.0.1:
     ember-cli-babel "^7.26.11"
     ember-cli-babel-plugin-helpers "^1.1.1"
 
-ember-classic-decorator@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ember-classic-decorator/-/ember-classic-decorator-3.0.1.tgz#13acf53e5fdb1f867919765853eb3592380ed1ef"
-  integrity sha512-IoocHPX1cY93Sma7VeDGbF0M1+TkBWDJLus+RD01902eD+KHEL2+diwM+iayCyO+1/xaUzdzNGh35J+i+TCxoA==
-  dependencies:
-    "@embroider/macros" "^1.0.0"
-    babel-plugin-filter-imports "^4.0.0"
-    ember-cli-babel "^7.26.11"
-    ember-cli-htmlbars "^6.0.1"
-
 ember-cli-addon-docs-yuidoc@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-addon-docs-yuidoc/-/ember-cli-addon-docs-yuidoc-1.0.0.tgz#0bc750c3950d77fbcce645855063013b295ee6be"


### PR DESCRIPTION
ember-classic-decorator was supposed to be used during the transition period while converting from classic classes to native.

It is time to get rid of it as it creates issues like this: https://github.com/emberjs/ember-classic-decorator/issues/99 https://github.com/emberjs/ember-classic-decorator/issues/74 etc.

The transition is easy, just replace this.set with set(this, ...