### PR TITLE
Use ES6 initialization for EVENT_THROTTLE

### DIFF
--- a/addon/services/user-activity.js
+++ b/addon/services/user-activity.js
@@ -8,7 +8,7 @@ import storageAvailable from '../utils/storage-available';
 export default class UserActivityService extends FastBootAwareEventManagerService {
   @service scrollActivity;
 
-  EVENT_THROTTLE;
+  EVENT_THROTTLE = 100;
   defaultEvents = ['keydown', 'mousedown', 'scroll', 'touchstart', 'storage'];
   enabledEvents = A();
   _eventsListened = A();
@@ -23,7 +23,9 @@ export default class UserActivityService extends FastBootAwareEventManagerServic
     super.init(...arguments);
 
     // Do not throttle in testing mode
-    this.EVENT_THROTTLE = Ember.testing ? 0 : 100;
+    if (Ember.testing) {
+      this.EVENT_THROTTLE = 0;
+    }
 
     this._boundEventHandler = this.handleEvent.bind(this);
 


### PR DESCRIPTION
We shouldn't be setting this in init/constructor if we want people to be able to override the default value easily.

Fixes #1072