### PR TITLE
chore: Remove Ember.testing deprecation

### DIFF
--- a/addon/services/user-activity.js
+++ b/addon/services/user-activity.js
@@ -1,5 +1,5 @@
 import FastBootAwareEventManagerService from 'ember-user-activity/services/-private/fastboot-aware-event-manager';
-import Ember from 'ember';
+import { isTesting } from '@ember/debug';
 import { A } from '@ember/array';
 import { throttle } from '@ember/runloop';
 import { service } from '@ember/service';
@@ -23,7 +23,7 @@ export default class UserActivityService extends FastBootAwareEventManagerServic
     super.init(...arguments);
 
     // Do not throttle in testing mode
-    if (Ember.testing) {
+    if (isTesting()) {
       this.EVENT_THROTTLE = 0;
     }
 

--- a/addon/services/user-idle.js
+++ b/addon/services/user-idle.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { isTesting } from '@ember/debug';
 import EventManagerService from 'ember-user-activity/services/-private/event-manager';
 import { service } from '@ember/service';
 import { cancel, debounce } from '@ember/runloop';
@@ -23,7 +23,7 @@ export default class UserIdleService extends EventManagerService {
   init() {
     super.init(...arguments);
 
-    if (Ember.testing) {
+    if (isTesting()) {
       // Shorter debounce in testing mode
       this.IDLE_TIMEOUT = 10;
     }


### PR DESCRIPTION
https://deprecations.emberjs.com/id/deprecate-import-testing-from-ember